### PR TITLE
Exclude vendored gems from coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ Bundler.require(:default, :test)
 SimpleCov.start do
   enable_coverage :branch
   load_profile 'test_frameworks'
+  add_filter %r{^/vendor/}
   track_files 'lib/**/*.rb'
 end
 


### PR DESCRIPTION
Travis installs gems in the `vendor/` directory, so our CI coverage number was including all required gems.