### PR TITLE
Fix disabling of the rspec-rails cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,5 +27,5 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 4
 
-RSpec/Rails:
+RSpecRails:
   Enabled: false


### PR DESCRIPTION
The Rspec Rails cops are now a separate gem.

We still don't want them, though.