### PR TITLE
Fix docs task committing to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,24 +7,32 @@ on:
       - 'README.md'
       - 'lib/**/*.rb'
 jobs:
-  rdoc:
+  build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: docs-github-app-token
+        with:
+          app-id: ${{ vars.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_SECRET_KEY }}
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.docs-github-app-token.outputs.token }}
       - uses: ./.github/actions/setup
       - run: 'bin/rake rdoc'
       - run: |-
           git config --global user.name 'GitHub Actions'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add docs/
-          git commit -m 'Update documentation' || true
+          git commit -m 'Update documentation [skip ci]' || true
           git push
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
+
   deploy:
     runs-on: ubuntu-latest
-    needs: rdoc
+    needs: build
     permissions:
       pages: write
       id-token: write

--- a/lib/dev_training/readme.rb
+++ b/lib/dev_training/readme.rb
@@ -45,17 +45,26 @@ module DevTraining
       @resource ||= readme || create_readme
     end
 
-    ##
+    # ---------------------------------------------------------------------
+    # :section: Template Helper Methods
+    #
     # These protected methods act as helper methods in the template rendering
     # context. Note that even private methods can work this way, but keeping
     # these methods grouped under protected is a useful naming convention.
+    # ---------------------------------------------------------------------
+
     protected
 
+    ##
+    # Constructs an absolute URL relative to the repository's URL
     def repo_relative(path)
       base = URI.parse(@repo.resource.html_url)
       URI.join(base, "#{base.path}/#{path}")
     end
 
+    ##
+    # The user's "real" name if available, or their login name as a fallback
+    # (many folks leave their name blank)
     def user_name
       @client.user.name || @client.user.login
     end


### PR DESCRIPTION
This action does its git work as a [GH app owned by umts](https://github.com/apps/umts-dev-training-docs). I also switched this repository to use the new "[rulesets](https://github.com/umts/dev-training-web/settings/rules)" instead of a branch protection rule, which allows us to allow said app to bypass it.

Finally, it turns out that said commit _was_ still triggering a test run; changed it to use "skip ci".