### PR TITLE
Switch Capistrano yarn tasks to npm

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,10 +15,10 @@ set :deploy_to, "/srv/#{fetch :application}"
 set :keep_releases, 5
 
 append :linked_files, 'config/application.yml'
-append :linked_dirs, 'log', 'node_modules', 'public/assets'
+append :linked_dirs, 'log', 'public/assets'
 
 before 'git:check', 'git:allow_shared'
-before 'deploy:updated', 'yarn:install'
+before 'deploy:updated', 'npm:install'
 
 set :log_level, :info
 

--- a/lib/capistrano/tasks/npm.rake
+++ b/lib/capistrano/tasks/npm.rake
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
-namespace :yarn do
-  desc 'Install the project dependencies via yarn.'
+namespace :npm do
+  desc 'Install the project dependencies via npm.'
   task :install do
     on roles :web do
       within release_path do
-        execute :yarn, 'install', %w[--production]
+        execute :npm, 'install', %w[--production --silent --no-spin]
       end
     end
   end
 
-  desc 'Remove extraneous packages via yarn.'
+  desc 'Remove extraneous packages via npm.'
   task :prune do
     on roles :web do
       within release_path do
-        execute :yarn, 'prune'
+        execute :npm, 'prune', %w[--production]
       end
     end
   end
 
-  desc 'Rebuild via yarn'
+  desc 'Rebuild via npm'
   task :rebuild do
     on roles :web do
       within release_path do
-        execute :yarn, 'rebuild'
+        execute :npm, 'rebuild'
       end
     end
   end


### PR DESCRIPTION
I "switched" to npm in #154 a while back, but forgot these Capistrano tasks.

Which means we were still running `yarn install` on deploy, effectively ignoring the `package-lock.json` file.

This is why deployment broke recently. There's a new version of PicoCSS (#212) and yarn just... installed it.