### PR TITLE
Require credentials key in production

### DIFF
--- a/config/credentials.rb
+++ b/config/credentials.rb
@@ -6,5 +6,5 @@ CREDENTIALS = ActiveSupport::EncryptedConfiguration.new(
   config_path: File.expand_path('dev-training-web.yml.enc', __dir__),
   key_path: File.expand_path('dev-training-web.key', __dir__),
   env_key: 'MASTER_KEY',
-  raise_if_missing_key: false
+  raise_if_missing_key: ENV['RACK_ENV'] == 'production'
 )


### PR DESCRIPTION
`lib/application_secrets.rb` assumes they'll be there in 'prod'

In reviewing #342, I built a "production" container locally without realizing that I was missing the `.key` file and got:

```
        SECURITY WARNING: No secret option provided to Rack::Session::Cookie.
        This poses a security threat. It is strongly recommended that you
        provide a secret to prevent exploits that may be possible from crafted
        cookies. This will not be supported in future versions of Rack, and
        future versions will even invalidate your existing user cookies.
```

We shouldn't boot with blank secrets