### PR TITLE
Ignore unescaped html in layout yield

### DIFF
--- a/views/application.haml
+++ b/views/application.haml
@@ -13,6 +13,7 @@
 
   %body
     %main
+      -# haml-lint:disable UnescapedHtml
       != yield
 
     %footer


### PR DESCRIPTION
This should be fine since `yield` is only the result of rendering another Haml template, and thus is sanitized.