### PR TITLE
Remove lint/test Rake tasks and the default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,11 +59,10 @@ namespace :credentials do
 end
 
 unless ENV.fetch('RACK_ENV', 'development') == 'production'
-  require 'fileutils'
-  require 'haml_lint/rake_task'
   require 'rdoc/task'
-  require 'rspec/core/rake_task'
-  require 'rubocop/rake_task'
+
+  desc 'Prepare for testing'
+  task 'test:prepare' => 'css:build'
 
   RDoc::Task.new do |rdoc|
     rdoc.markup = 'markdown'
@@ -71,33 +70,5 @@ unless ENV.fetch('RACK_ENV', 'development') == 'production'
     rdoc.rdoc_files.include('README.md', 'lib/**/*.rb')
     rdoc.main = 'README.md'
     rdoc.rdoc_dir = 'docs'
-  end
-
-  RuboCop::RakeTask.new do |rubocop|
-    next unless ENV['CI']
-
-    rubocop.options = [['--fail-level', 'W'], '--display-only-fail-level-offenses', '--fail-fast']
-    rubocop.formatters = ['simple']
-  end
-
-  HamlLint::RakeTask.new do |hl|
-    next unless ENV['CI']
-
-    hl.fail_level = 'error'
-    hl.quiet = false
-  end
-
-  desc 'Prepare for testing'
-  task 'test:prepare' => 'css:build'
-
-  RSpec::Core::RakeTask.new(:spec) do |rspec|
-    next unless ENV['CI']
-
-    rspec.rspec_opts = ['--format progress', '--fail-fast', '--no-profile']
-  end
-
-  desc 'Run all tests and linters.'
-  task :default do
-    %w[spec rubocop haml_lint].each { |t| Rake::Task[t].invoke }
   end
 end


### PR DESCRIPTION
Now that CI doesn't use it, I don't think our devs are really used to the pattern, "run `rake` to run all the checks".